### PR TITLE
YTPOS-65 Email Regex adjustment

### DIFF
--- a/cartridges/int_yotpo_sfra/cartridge/scripts/utils/constants.js
+++ b/cartridges/int_yotpo_sfra/cartridge/scripts/utils/constants.js
@@ -26,7 +26,7 @@ exports.REGEX_BASE_FOR_YOTPO_DATA = '^0-9a-zA-Z';
 exports.REGEX_FOR_YOTPO_DATA_SAFE_SPECIAL_CHARS = ':,\\.\\?\\!\\|\\+\\_\\-=\\$\\*#%& ';
 exports.REGEX_FOR_YOTPO_PRODUCT_ID_DATA_SAFE_SPECIAL_CHARS = '\\_\\- ';
 // RFC 5322 Official Standard regex
-exports.EMAIL_VALIDATION_REGEX_FOR_YOTPO_DATA = /(?:[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/i;  // eslint-disable-line
+exports.EMAIL_VALIDATION_REGEX_FOR_YOTPO_DATA = /^(?:[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/i;  // eslint-disable-line
 exports.EMAIL_REGEX_FOR_YOTPO_DATA = ' ';
 exports.SERVICE_MAX_TIMEOUTS = 5;
 exports.PRODUCT_ID_TOKEN = 'PRODUCT_ID__';

--- a/cartridges/int_yotpo_sfra/cartridge/scripts/utils/constants.js
+++ b/cartridges/int_yotpo_sfra/cartridge/scripts/utils/constants.js
@@ -26,6 +26,7 @@ exports.REGEX_BASE_FOR_YOTPO_DATA = '^0-9a-zA-Z';
 exports.REGEX_FOR_YOTPO_DATA_SAFE_SPECIAL_CHARS = ':,\\.\\?\\!\\|\\+\\_\\-=\\$\\*#%& ';
 exports.REGEX_FOR_YOTPO_PRODUCT_ID_DATA_SAFE_SPECIAL_CHARS = '\\_\\- ';
 // RFC 5322 Official Standard regex
+// Note that this regex will filter out potentially valid email addresses if they use certain special unicode characters.
 exports.EMAIL_VALIDATION_REGEX_FOR_YOTPO_DATA = /^(?:[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/i;  // eslint-disable-line
 exports.EMAIL_REGEX_FOR_YOTPO_DATA = ' ';
 exports.SERVICE_MAX_TIMEOUTS = 5;


### PR DESCRIPTION
YTPOS-65 adjust email validation regex so it only matches if entire email string matches and will not match substrings.

This makes it more resilient against special unicode characters that the Yotpo API is not currently capable of handling. Note that this regex will filter out potentially valid email addresses if they use certain unicode characters.