### PR TITLE
YTPOS-65 end job when there are no orders to process to avoid errors

### DIFF
--- a/cartridges/int_yotpo_sfra/cartridge/scripts/job/exportOrders.js
+++ b/cartridges/int_yotpo_sfra/cartridge/scripts/job/exportOrders.js
@@ -189,7 +189,8 @@ function afterChunk(success) {
         var exportOrderModelInstance = new ExportOrderModel();
 
         if (empty(latestOrderDateTime)) {
-            yotpoLogger.logMessage('No orders to process. Ending job to avoid errors');
+            // exiting job here to prevent the comparison below from blowing up if latestOrderDateTime is undefined
+            yotpoLogger.logMessage('No orders to process. Exiting job.');
             return;
         }
 

--- a/cartridges/int_yotpo_sfra/cartridge/scripts/job/exportOrders.js
+++ b/cartridges/int_yotpo_sfra/cartridge/scripts/job/exportOrders.js
@@ -188,6 +188,11 @@ function afterChunk(success) {
         var ExportOrderModel = require('*/cartridge/models/orderexport/exportOrderModel');
         var exportOrderModelInstance = new ExportOrderModel();
 
+        if (empty(latestOrderDateTime)) {
+            yotpoLogger.logMessage('No orders to process. Ending job to avoid errors');
+            return;
+        }
+
         var isSameTime = originalLastExecutionDateTime.valueOf() === latestOrderDateTime.valueOf();
         if (isSameTime) {
             yotpoLogger.logMessage('New job execution time is identical to previous value; shifting ahead one minute to prevent endless loop', 'error', logLocation);


### PR DESCRIPTION
When the job was dry run with no available orders to export, it would result in an error as there would be no `latestOrderDateTime` to compare to. This ends the job on a dry run before that error happens.