### PR TITLE
Empty products skipped order logging

### DIFF
--- a/cartridges/int_yotpo_sfra/cartridge/models/orderexport/exportOrderModel.js
+++ b/cartridges/int_yotpo_sfra/cartridge/models/orderexport/exportOrderModel.js
@@ -671,6 +671,8 @@ function prepareOrderData(order, dateTimes) {
                 currency_iso: order.currencyCode,
                 products: products
             });
+    } else {
+        throw new Error('Skipping order ' + orderNo + ' in the export due to empty products array. No products or gift cards in order.');
     }
 
     return orderData;


### PR DESCRIPTION
YTPOS-65 properly log skipped order when products array is empty