### PR TITLE
Feature/ytpos 115 missing regex

### DIFF
--- a/cartridges/int_yotpo_sfra/cartridge/scripts/utils/constants.js
+++ b/cartridges/int_yotpo_sfra/cartridge/scripts/utils/constants.js
@@ -23,6 +23,8 @@ exports.DATE_FORMAT_FOR_YOTPO_DATA = 'yyyy-MM-dd';
 exports.PLATFORM_FOR_YOTPO_DATA = 'commerce_cloud';
 exports.YOTPO_CARTRIDGE_VERSION = '21.5.1';
 exports.REGEX_BASE_FOR_YOTPO_DATA = '^0-9a-zA-Z';
+exports.PRODUCT_REGEX_FOR_YOTPO_DATA = '[^0-9a-zA-Z\\_\\-]+' // temporary regex. Needs confirmation
+exports.REGEX_FOR_YOTPO_DATA = '[^0-9a-zA-Z\\_\\-]+' // temporary regex. Needs confirmation
 exports.REGEX_FOR_YOTPO_DATA_SAFE_SPECIAL_CHARS = ':,\\.\\?\\!\\|\\+\\_\\-=\\$\\*#%& ';
 exports.REGEX_FOR_YOTPO_PRODUCT_ID_DATA_SAFE_SPECIAL_CHARS = '\\_\\- ';
 // RFC 5322 Official Standard regex

--- a/cartridges/int_yotpo_sfra/cartridge/scripts/utils/constants.js
+++ b/cartridges/int_yotpo_sfra/cartridge/scripts/utils/constants.js
@@ -23,8 +23,8 @@ exports.DATE_FORMAT_FOR_YOTPO_DATA = 'yyyy-MM-dd';
 exports.PLATFORM_FOR_YOTPO_DATA = 'commerce_cloud';
 exports.YOTPO_CARTRIDGE_VERSION = '21.5.1';
 exports.REGEX_BASE_FOR_YOTPO_DATA = '^0-9a-zA-Z';
-exports.PRODUCT_REGEX_FOR_YOTPO_DATA = '[^0-9a-zA-Z\\_\\-]+' // temporary regex. Needs confirmation
-exports.REGEX_FOR_YOTPO_DATA = '[^0-9a-zA-Z\\_\\-]+' // temporary regex. Needs confirmation
+exports.PRODUCT_REGEX_FOR_YOTPO_DATA = '[^0-9a-zA-Z\\_\\-]+';
+exports.REGEX_FOR_YOTPO_DATA = '[^0-9a-zA-Z\\s\\_\\-]+'; // allowing whitespace in this one
 exports.REGEX_FOR_YOTPO_DATA_SAFE_SPECIAL_CHARS = ':,\\.\\?\\!\\|\\+\\_\\-=\\$\\*#%& ';
 exports.REGEX_FOR_YOTPO_PRODUCT_ID_DATA_SAFE_SPECIAL_CHARS = '\\_\\- ';
 // RFC 5322 Official Standard regex

--- a/cartridges/int_yotpo_sfra/cartridge/scripts/utils/yotpoUtils.js
+++ b/cartridges/int_yotpo_sfra/cartridge/scripts/utils/yotpoUtils.js
@@ -15,7 +15,9 @@
  * @returns {string} escapedText
  */
 function escape(text, regex, replacement) {
-    if (!text) {
+    // undefined regex causes slightly different behavior of .replace() between compatibility modes
+    // so make sure we have regex instead of just assuming that .replace() will just return the text
+    if (!text || !regex) {
         return text;
     }
 


### PR DESCRIPTION
The regex strings `PRODUCT_REGEX_FOR_YOTPO_DATA` and `REGEX_FOR_YOTPO_DATA` referenced on lines 202 and 203 of `loyaltyOrderModel.js` were missing, so this PR adds them. Previously, the `RegExp.replace()` method didn't change the text it was matching to the regex if the regex was `null` or `undefined`, so the issue was never noticed. But with newer JS/SFCC compatibility mode versions, the functionality differed slightly, bringing this issue to our attention.

Link to ticket: https://cqlcorp.atlassian.net/browse/YTPOS-115