### PR TITLE
YTPOS-118 email validation regex

### DIFF
--- a/cartridges/int_yotpo_sfra/cartridge/scripts/utils/constants.js
+++ b/cartridges/int_yotpo_sfra/cartridge/scripts/utils/constants.js
@@ -29,8 +29,9 @@ exports.REGEX_FOR_YOTPO_DATA_SAFE_SPECIAL_CHARS = ':,\\.\\?\\!\\|\\+\\_\\-=\\$\\
 exports.REGEX_FOR_YOTPO_PRODUCT_ID_DATA_SAFE_SPECIAL_CHARS = '\\_\\- ';
 // The email validation regex that the Yotpo API is using (PCRE2 flavor): /\A\s*([#-\\p{L}\\d+._" : "^@\\s]{1,64})@((?:[-\p{L}\d]+\.)+\p{L}{2,})\s*\z/i
 // The below email regex is that regex converted to work with JavaScript
+// The regex that the API uses may not be RFC-compliant, but it seems like it covers the majority of good/bad email cases correctly.
 // Note that this regex will filter out potentially valid email addresses if they use certain special unicode characters.
-exports.EMAIL_VALIDATION_REGEX_FOR_YOTPO_DATA = /^\s*([#-\u002D\u002E\u003A-\u0040a-zA-Z0-9_"\s]{1,64})@((?:[-a-zA-Z0-9]+\.)+[a-zA-Z]{2,})\s*$/i;  // eslint-disable-line
+exports.EMAIL_VALIDATION_REGEX_FOR_YOTPO_DATA = /^\s*([#-\u002D\u002E\u003A-\u0040a-zA-Z0-9_" /\[\\^\{\}]{1,64})@((?:[-a-zA-Z0-9\u00AA\u00B5\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u0100]+\.)+[a-zA-Z\u00AA\u00B5\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u0100]{2,})\s*$/i;  // eslint-disable-line
 exports.EMAIL_REGEX_FOR_YOTPO_DATA = ' ';
 exports.SERVICE_MAX_TIMEOUTS = 5;
 exports.PRODUCT_ID_TOKEN = 'PRODUCT_ID__';

--- a/cartridges/int_yotpo_sfra/cartridge/scripts/utils/constants.js
+++ b/cartridges/int_yotpo_sfra/cartridge/scripts/utils/constants.js
@@ -30,6 +30,8 @@ exports.REGEX_FOR_YOTPO_PRODUCT_ID_DATA_SAFE_SPECIAL_CHARS = '\\_\\- ';
 // The email validation regex that the Yotpo API is using (PCRE2 flavor): /\A\s*([#-\\p{L}\\d+._" : "^@\\s]{1,64})@((?:[-\p{L}\d]+\.)+\p{L}{2,})\s*\z/i
 // The below email regex is that regex converted to work with JavaScript
 // The regex that the API uses may not be RFC-compliant, but it seems like it covers the majority of good/bad email cases correctly.
+// Previously an RFC-spec regex was used, but it allowed some emails through that the Yotpo API rejected, so this was updated to match the
+// regex used by the Yotpo API as close as possible.
 // Note that this regex will filter out potentially valid email addresses if they use certain special unicode characters.
 exports.EMAIL_VALIDATION_REGEX_FOR_YOTPO_DATA = /^\s*([#-\u002D\u002E\u003A-\u0040a-zA-Z0-9_" /\[\\^\{\}]{1,64})@((?:[-a-zA-Z0-9\u00AA\u00B5\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u0100]+\.)+[a-zA-Z\u00AA\u00B5\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u0100]{2,})\s*$/i;  // eslint-disable-line
 exports.EMAIL_REGEX_FOR_YOTPO_DATA = ' ';

--- a/cartridges/int_yotpo_sfra/cartridge/scripts/utils/constants.js
+++ b/cartridges/int_yotpo_sfra/cartridge/scripts/utils/constants.js
@@ -27,9 +27,10 @@ exports.PRODUCT_REGEX_FOR_YOTPO_DATA = '[^0-9a-zA-Z\\_\\-]+';
 exports.REGEX_FOR_YOTPO_DATA = '[^0-9a-zA-Z\\s\\_\\-]+'; // allowing whitespace in this one
 exports.REGEX_FOR_YOTPO_DATA_SAFE_SPECIAL_CHARS = ':,\\.\\?\\!\\|\\+\\_\\-=\\$\\*#%& ';
 exports.REGEX_FOR_YOTPO_PRODUCT_ID_DATA_SAFE_SPECIAL_CHARS = '\\_\\- ';
-// RFC 5322 Official Standard regex
+// The email validation regex that the Yotpo API is using (PCRE2 flavor): /\A\s*([#-\\p{L}\\d+._" : "^@\\s]{1,64})@((?:[-\p{L}\d]+\.)+\p{L}{2,})\s*\z/i
+// The below email regex is that regex converted to work with JavaScript
 // Note that this regex will filter out potentially valid email addresses if they use certain special unicode characters.
-exports.EMAIL_VALIDATION_REGEX_FOR_YOTPO_DATA = /^(?:[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/i;  // eslint-disable-line
+exports.EMAIL_VALIDATION_REGEX_FOR_YOTPO_DATA = /^\s*([#-\u002D\u002E\u003A-\u0040a-zA-Z0-9_"\s]{1,64})@((?:[-a-zA-Z0-9]+\.)+[a-zA-Z]{2,})\s*$/i;  // eslint-disable-line
 exports.EMAIL_REGEX_FOR_YOTPO_DATA = ' ';
 exports.SERVICE_MAX_TIMEOUTS = 5;
 exports.PRODUCT_ID_TOKEN = 'PRODUCT_ID__';

--- a/cartridges/int_yotpo_sfra/cartridge/scripts/utils/yotpoUtils.js
+++ b/cartridges/int_yotpo_sfra/cartridge/scripts/utils/yotpoUtils.js
@@ -98,7 +98,7 @@ function getCurrentLocaleSFRA(currentLocaleID) {
 }
 
 /**
- * Validates given email address based on RFC 5322 Official Standard regex
+ * Validates given email address based on regex used by the Yotpo API (see constants.js)
  * @param {string} emailAddress email address to validate
  * @returns {boolean} true if email is valid based on regex
  */


### PR DESCRIPTION
YTPOS-118 adjust email validation regex to match Yotpo API email validation regex.

Yotpo API uses regex `/\A\s*([#-\\p{L}\\d+._" : "^@\\s]{1,64})@((?:[-\p{L}\d]+\.)+\p{L}{2,})\s*\z/i`, and as far as I can tell in my testing, this regex passes/fails all the same values in JavaScript