### PR TITLE
YTPOS-119 access correct property value

### DIFF
--- a/cartridges/int_yotpo_sfra/cartridge/scripts/common/integrationHelper.js
+++ b/cartridges/int_yotpo_sfra/cartridge/scripts/common/integrationHelper.js
@@ -76,7 +76,7 @@ function getConversionTrackingData(order, currentLocale) {
         }
 
         var Site = require('dw/system/Site');
-        var yotpoAppKey = yotpoConfig.yotpoAppKey;
+        var yotpoAppKey = yotpoConfig.appKey;
         var conversionTrackingURL = Site.getCurrent().preferences.custom.yotpoConversionTrackingPixelURL;
         conversionTrkURL = conversionTrackingURL + '?order_amount=' + orderTotalValue +
             '&order_id=' + order.orderNo + '&order_currency=' + order.currencyCode + '&app_key=' + yotpoAppKey;

--- a/cartridges/int_yotpo_sfra/cartridge/scripts/common/integrationHelper.js
+++ b/cartridges/int_yotpo_sfra/cartridge/scripts/common/integrationHelper.js
@@ -33,7 +33,7 @@ function getRatingsOrReviewsData(currentLocale, productId) {
         return {
             isReviewsEnabled: yotpoConfig.isReviewsEnabled,
             isRatingsEnabled: yotpoConfig.isRatingsEnabled,
-            yotpoAppKey: yotpoConfig.yotpoAppKey,
+            yotpoAppKey: yotpoConfig.appKey,
             domainAddress: yotpoConfig.domainAddress,
             productID: yotpoUtils.escape(currentProduct.ID, '([\/])', '-'),
             productName: currentProduct.name,


### PR DESCRIPTION
Likely this was an issue stemming from an old version of the cartridge that didn't get updated with the rest of the code.

The property `yotpoAppKey` didn't exist. Looking at what's available inside the `yotpoConfig` object,  it appears the intended property to be accessed was `appKey`.