### PR TITLE
YTPOS_59 replace deprecated global .replace() flag with global regex

### DIFF
--- a/cartridges/int_yotpo_sfra/cartridge/models/orderexport/exportOrderModel.js
+++ b/cartridges/int_yotpo_sfra/cartridge/models/orderexport/exportOrderModel.js
@@ -778,7 +778,7 @@ function sendOrdersToYotpo(requestData, yotpoAppKey, locale, shouldGetNewToken) 
         exportOrderServiceRegistry.yotpoExportOrdersSvc.setURL(yotpoURL);
 
         // Removing the prefix that was added earlier to workaround SFCC not allowing object keys to start with '0.'
-        var requestJson = JSON.stringify(requestData).replace(constants.PRODUCT_ID_TOKEN, '', 'g');
+        var requestJson = JSON.stringify(requestData).replace(constants.PRODUCT_ID_PREFIX_REGEX, '');
         var result = exportOrderServiceRegistry.yotpoExportOrdersSvc.call(requestJson);
         var responseStatus = this.parseYotpoResponse(result);
         authenticationError = responseStatus.authenticationError;

--- a/cartridges/int_yotpo_sfra/cartridge/scripts/utils/constants.js
+++ b/cartridges/int_yotpo_sfra/cartridge/scripts/utils/constants.js
@@ -37,6 +37,8 @@ exports.EMAIL_VALIDATION_REGEX_FOR_YOTPO_DATA = /^\s*([#-\u002D\u002E\u003A-\u00
 exports.EMAIL_REGEX_FOR_YOTPO_DATA = ' ';
 exports.SERVICE_MAX_TIMEOUTS = 5;
 exports.PRODUCT_ID_TOKEN = 'PRODUCT_ID__';
+// use this regex to remove above prefix, as passing the global flag into .replace() is deprecated on newer compatibility modes
+exports.PRODUCT_ID_PREFIX_REGEX = /PRODUCT_ID__/g;
 // Used to calculate % threshold of skipped orders. Once reached the
 // job is flagged with an ERROR status that is displayed in the BM
 exports.EXPORT_ORDER_ERROR_COUNT_THRESHOLD = 0.03;


### PR DESCRIPTION
.replace() with three parameters is deprecated on newer compatibility modes and no longer works