### PR TITLE
fix(yotpoUtils.js): Proper handling empty category.

### DIFF
--- a/cartridges/int_yotpo_sfra/cartridge/scripts/utils/yotpoUtils.js
+++ b/cartridges/int_yotpo_sfra/cartridge/scripts/utils/yotpoUtils.js
@@ -52,7 +52,7 @@ function getCategoryPath(product, separator) {
     var cat = theCategory;
     var path = [];
 
-    while (cat.parent != null) {
+    while (!empty(cat) && (cat.parent != null)) {
         if (cat.online) {
             path[0] = cat.getDisplayName();
         }

--- a/test/unit/int_yotpo_sfra/scripts/utils/YotpoUtils.js
+++ b/test/unit/int_yotpo_sfra/scripts/utils/YotpoUtils.js
@@ -381,5 +381,16 @@ describe('yotpoUtils', () => {
             const result = yotpoUtils.getCategoryPath(product);
             assert.equal(result, 'Parent Product Primary Category Name');
         });
+
+        it('should return empty string when product has no primary category', () => {
+            const product = getProductMock();
+
+            product.isVariant = () => false;
+            product.getPrimaryCategory = () => null;
+            product.categories = [];
+
+            const result = yotpoUtils.getCategoryPath(product);
+            assert.equal(result, '');
+        });
     });
 });


### PR DESCRIPTION
User description:

> This is one spot where we have discovered an issue, especially if a product no longer is  categorized when then order sending job that picks up custom objects, or if a product is a  variant and the parent product is not categorized. The issue is around the “cat.parent” call,  and if “cat” is null/undefined, then the upstream process that calls this code is skipped and  a custom object never gets created on order placement/confirmation. This can happen in  real time when an order is placed, or when the order job runs that checks for custom  objects that need to be sent.

https://yotpoent.atlassian.net/browse/LYRF-12790